### PR TITLE
allow easy modifications of ffmpeg command line. fixes #23

### DIFF
--- a/MainForm.Designer.cs
+++ b/MainForm.Designer.cs
@@ -30,23 +30,25 @@ namespace WebMConverter
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(MainForm));
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
-            this.groupBox1 = new System.Windows.Forms.GroupBox();
-            this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
-            this.buttonBrowseOut = new System.Windows.Forms.Button();
-            this.textBoxOut = new System.Windows.Forms.TextBox();
-            this.label4 = new System.Windows.Forms.Label();
-            this.label1 = new System.Windows.Forms.Label();
-            this.textBoxIn = new System.Windows.Forms.TextBox();
-            this.buttonGo = new System.Windows.Forms.Button();
-            this.buttonBrowseIn = new System.Windows.Forms.Button();
-            this.groupBox2 = new System.Windows.Forms.GroupBox();
-            this.tableLayoutPanel3 = new System.Windows.Forms.TableLayoutPanel();
-            this.groupBox4 = new System.Windows.Forms.GroupBox();
-            this.tableLayoutPanel5 = new System.Windows.Forms.TableLayoutPanel();
+            this.groupBox3 = new System.Windows.Forms.GroupBox();
+            this.tableLayoutPanel4 = new System.Windows.Forms.TableLayoutPanel();
+            this.label7 = new System.Windows.Forms.Label();
+            this.label9 = new System.Windows.Forms.Label();
+            this.tableLayoutPanel10 = new System.Windows.Forms.TableLayoutPanel();
+            this.trackThreads = new System.Windows.Forms.TrackBar();
+            this.labelThreads = new System.Windows.Forms.Label();
             this.label18 = new System.Windows.Forms.Label();
             this.checkBox2Pass = new System.Windows.Forms.CheckBox();
-            this.label9 = new System.Windows.Forms.Label();
-            this.label7 = new System.Windows.Forms.Label();
+            this.label3 = new System.Windows.Forms.Label();
+            this.textBoxArguments = new System.Windows.Forms.TextBox();
+            this.label21 = new System.Windows.Forms.Label();
+            this.groupBox5 = new System.Windows.Forms.GroupBox();
+            this.tableLayoutPanel11 = new System.Windows.Forms.TableLayoutPanel();
+            this.label19 = new System.Windows.Forms.Label();
+            this.boxMetadataTitle = new System.Windows.Forms.TextBox();
+            this.label20 = new System.Windows.Forms.Label();
+            this.groupBox4 = new System.Windows.Forms.GroupBox();
+            this.tableLayoutPanel5 = new System.Windows.Forms.TableLayoutPanel();
             this.tableLayoutPanel9 = new System.Windows.Forms.TableLayoutPanel();
             this.boxCropTo = new System.Windows.Forms.TextBox();
             this.boxCropFrom = new System.Windows.Forms.TextBox();
@@ -69,51 +71,570 @@ namespace WebMConverter
             this.boxResH = new System.Windows.Forms.TextBox();
             this.boxResW = new System.Windows.Forms.TextBox();
             this.label8 = new System.Windows.Forms.Label();
-            this.tableLayoutPanel10 = new System.Windows.Forms.TableLayoutPanel();
-            this.trackThreads = new System.Windows.Forms.TrackBar();
-            this.labelThreads = new System.Windows.Forms.Label();
-            this.groupBox3 = new System.Windows.Forms.GroupBox();
-            this.tableLayoutPanel4 = new System.Windows.Forms.TableLayoutPanel();
-            this.label3 = new System.Windows.Forms.Label();
-            this.checkBoxAudio = new System.Windows.Forms.CheckBox();
-            this.groupBox5 = new System.Windows.Forms.GroupBox();
-            this.tableLayoutPanel11 = new System.Windows.Forms.TableLayoutPanel();
-            this.label19 = new System.Windows.Forms.Label();
-            this.boxMetadataTitle = new System.Windows.Forms.TextBox();
-            this.label20 = new System.Windows.Forms.Label();
+            this.groupBox1 = new System.Windows.Forms.GroupBox();
+            this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
+            this.buttonBrowseOut = new System.Windows.Forms.Button();
+            this.textBoxOut = new System.Windows.Forms.TextBox();
+            this.label4 = new System.Windows.Forms.Label();
+            this.label1 = new System.Windows.Forms.Label();
+            this.textBoxIn = new System.Windows.Forms.TextBox();
+            this.buttonGo = new System.Windows.Forms.Button();
+            this.buttonBrowseIn = new System.Windows.Forms.Button();
             this.tableLayoutPanel1.SuspendLayout();
-            this.groupBox1.SuspendLayout();
-            this.tableLayoutPanel2.SuspendLayout();
-            this.groupBox2.SuspendLayout();
-            this.tableLayoutPanel3.SuspendLayout();
+            this.groupBox3.SuspendLayout();
+            this.tableLayoutPanel4.SuspendLayout();
+            this.tableLayoutPanel10.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.trackThreads)).BeginInit();
+            this.groupBox5.SuspendLayout();
+            this.tableLayoutPanel11.SuspendLayout();
             this.groupBox4.SuspendLayout();
             this.tableLayoutPanel5.SuspendLayout();
             this.tableLayoutPanel9.SuspendLayout();
             this.tableLayoutPanel7.SuspendLayout();
             this.tableLayoutPanel8.SuspendLayout();
             this.tableLayoutPanel6.SuspendLayout();
-            this.tableLayoutPanel10.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.trackThreads)).BeginInit();
-            this.groupBox3.SuspendLayout();
-            this.tableLayoutPanel4.SuspendLayout();
-            this.groupBox5.SuspendLayout();
-            this.tableLayoutPanel11.SuspendLayout();
+            this.groupBox1.SuspendLayout();
+            this.tableLayoutPanel2.SuspendLayout();
             this.SuspendLayout();
             // 
             // tableLayoutPanel1
             // 
             this.tableLayoutPanel1.ColumnCount = 1;
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel1.Controls.Add(this.groupBox3, 0, 3);
+            this.tableLayoutPanel1.Controls.Add(this.groupBox5, 0, 1);
+            this.tableLayoutPanel1.Controls.Add(this.groupBox4, 0, 2);
             this.tableLayoutPanel1.Controls.Add(this.groupBox1, 0, 0);
-            this.tableLayoutPanel1.Controls.Add(this.groupBox2, 0, 1);
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tableLayoutPanel1.Location = new System.Drawing.Point(3, 3);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
-            this.tableLayoutPanel1.RowCount = 2;
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 86F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(953, 438);
+            this.tableLayoutPanel1.RowCount = 3;
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 18.07512F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 12.20657F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 33.33333F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 36.85446F));
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(959, 432);
             this.tableLayoutPanel1.TabIndex = 0;
+            // 
+            // groupBox3
+            // 
+            this.groupBox3.AutoSize = true;
+            this.groupBox3.Controls.Add(this.tableLayoutPanel4);
+            this.groupBox3.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.groupBox3.Location = new System.Drawing.Point(3, 275);
+            this.groupBox3.Name = "groupBox3";
+            this.groupBox3.Size = new System.Drawing.Size(953, 154);
+            this.groupBox3.TabIndex = 6;
+            this.groupBox3.TabStop = false;
+            this.groupBox3.Text = "Advanced";
+            // 
+            // tableLayoutPanel4
+            // 
+            this.tableLayoutPanel4.ColumnCount = 3;
+            this.tableLayoutPanel4.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 31.19658F));
+            this.tableLayoutPanel4.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 68.80342F));
+            this.tableLayoutPanel4.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 695F));
+            this.tableLayoutPanel4.Controls.Add(this.label7, 0, 1);
+            this.tableLayoutPanel4.Controls.Add(this.label9, 2, 1);
+            this.tableLayoutPanel4.Controls.Add(this.tableLayoutPanel10, 1, 1);
+            this.tableLayoutPanel4.Controls.Add(this.label18, 2, 2);
+            this.tableLayoutPanel4.Controls.Add(this.checkBox2Pass, 0, 2);
+            this.tableLayoutPanel4.Controls.Add(this.label3, 0, 3);
+            this.tableLayoutPanel4.Controls.Add(this.textBoxArguments, 1, 3);
+            this.tableLayoutPanel4.Controls.Add(this.label21, 0, 0);
+            this.tableLayoutPanel4.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanel4.Location = new System.Drawing.Point(3, 16);
+            this.tableLayoutPanel4.Name = "tableLayoutPanel4";
+            this.tableLayoutPanel4.RowCount = 4;
+            this.tableLayoutPanel4.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            this.tableLayoutPanel4.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 33.33333F));
+            this.tableLayoutPanel4.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 28.57143F));
+            this.tableLayoutPanel4.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 38.77551F));
+            this.tableLayoutPanel4.Size = new System.Drawing.Size(947, 135);
+            this.tableLayoutPanel4.TabIndex = 0;
+            // 
+            // label7
+            // 
+            this.label7.AutoSize = true;
+            this.label7.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.label7.Location = new System.Drawing.Point(3, 20);
+            this.label7.Name = "label7";
+            this.label7.Size = new System.Drawing.Size(72, 38);
+            this.label7.TabIndex = 28;
+            this.label7.Text = "Threads:";
+            this.label7.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
+            // label9
+            // 
+            this.label9.AutoSize = true;
+            this.label9.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.label9.Location = new System.Drawing.Point(254, 20);
+            this.label9.Name = "label9";
+            this.label9.Size = new System.Drawing.Size(690, 38);
+            this.label9.TabIndex = 27;
+            this.label9.Text = "Determines amount of threads ffmpeg uses. Try setting this to 1 if ffmpeg.exe cra" +
+    "shes as soon as you click Convert.";
+            this.label9.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // tableLayoutPanel10
+            // 
+            this.tableLayoutPanel10.ColumnCount = 2;
+            this.tableLayoutPanel10.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 86.18421F));
+            this.tableLayoutPanel10.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 13.81579F));
+            this.tableLayoutPanel10.Controls.Add(this.trackThreads, 0, 0);
+            this.tableLayoutPanel10.Controls.Add(this.labelThreads, 1, 0);
+            this.tableLayoutPanel10.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanel10.Location = new System.Drawing.Point(81, 23);
+            this.tableLayoutPanel10.Name = "tableLayoutPanel10";
+            this.tableLayoutPanel10.RowCount = 1;
+            this.tableLayoutPanel10.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.tableLayoutPanel10.Size = new System.Drawing.Size(167, 32);
+            this.tableLayoutPanel10.TabIndex = 26;
+            // 
+            // trackThreads
+            // 
+            this.trackThreads.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.trackThreads.Location = new System.Drawing.Point(0, 0);
+            this.trackThreads.Margin = new System.Windows.Forms.Padding(0);
+            this.trackThreads.Maximum = 16;
+            this.trackThreads.Minimum = 1;
+            this.trackThreads.Name = "trackThreads";
+            this.trackThreads.Size = new System.Drawing.Size(143, 32);
+            this.trackThreads.TabIndex = 0;
+            this.trackThreads.Value = 1;
+            this.trackThreads.Scroll += new System.EventHandler(this.trackThreads_Scroll);
+            // 
+            // labelThreads
+            // 
+            this.labelThreads.AutoSize = true;
+            this.labelThreads.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.labelThreads.Location = new System.Drawing.Point(143, 0);
+            this.labelThreads.Margin = new System.Windows.Forms.Padding(0);
+            this.labelThreads.Name = "labelThreads";
+            this.labelThreads.Size = new System.Drawing.Size(24, 32);
+            this.labelThreads.TabIndex = 1;
+            this.labelThreads.Text = "1";
+            this.labelThreads.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // label18
+            // 
+            this.label18.AutoSize = true;
+            this.label18.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.label18.Location = new System.Drawing.Point(254, 58);
+            this.label18.Name = "label18";
+            this.label18.Size = new System.Drawing.Size(690, 32);
+            this.label18.TabIndex = 16;
+            this.label18.Text = "Will make ffmpeg use two passes, which can increase the quality/size ratio, but a" +
+    "lso increases the time it takes to encode. Disable if you run into any issues.";
+            this.label18.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.label18.Click += new System.EventHandler(this.label18_Click);
+            // 
+            // checkBox2Pass
+            // 
+            this.checkBox2Pass.CheckAlign = System.Drawing.ContentAlignment.MiddleRight;
+            this.tableLayoutPanel4.SetColumnSpan(this.checkBox2Pass, 2);
+            this.checkBox2Pass.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.checkBox2Pass.Location = new System.Drawing.Point(3, 61);
+            this.checkBox2Pass.Name = "checkBox2Pass";
+            this.checkBox2Pass.Size = new System.Drawing.Size(245, 26);
+            this.checkBox2Pass.TabIndex = 12;
+            this.checkBox2Pass.Text = "Enable 2-pass encoding:";
+            this.checkBox2Pass.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            this.checkBox2Pass.UseVisualStyleBackColor = true;
+            // 
+            // label3
+            // 
+            this.label3.AutoSize = true;
+            this.label3.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.label3.ImageAlign = System.Drawing.ContentAlignment.MiddleRight;
+            this.label3.Location = new System.Drawing.Point(3, 90);
+            this.label3.Name = "label3";
+            this.label3.Size = new System.Drawing.Size(72, 45);
+            this.label3.TabIndex = 29;
+            this.label3.Text = "Arguments";
+            this.label3.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
+            // textBoxArguments
+            // 
+            this.textBoxArguments.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.tableLayoutPanel4.SetColumnSpan(this.textBoxArguments, 2);
+            this.textBoxArguments.Location = new System.Drawing.Point(81, 102);
+            this.textBoxArguments.Name = "textBoxArguments";
+            this.textBoxArguments.Size = new System.Drawing.Size(858, 20);
+            this.textBoxArguments.TabIndex = 30;
+            // 
+            // label21
+            // 
+            this.label21.AutoSize = true;
+            this.tableLayoutPanel4.SetColumnSpan(this.label21, 3);
+            this.label21.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.label21.Location = new System.Drawing.Point(3, 0);
+            this.label21.Name = "label21";
+            this.label21.Size = new System.Drawing.Size(941, 20);
+            this.label21.TabIndex = 31;
+            this.label21.Text = "Don\'t modify these unless you know what you\'re doing!";
+            // 
+            // groupBox5
+            // 
+            this.groupBox5.Controls.Add(this.tableLayoutPanel11);
+            this.groupBox5.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.groupBox5.Location = new System.Drawing.Point(3, 80);
+            this.groupBox5.Name = "groupBox5";
+            this.groupBox5.Size = new System.Drawing.Size(953, 46);
+            this.groupBox5.TabIndex = 5;
+            this.groupBox5.TabStop = false;
+            this.groupBox5.Text = "Metadata";
+            // 
+            // tableLayoutPanel11
+            // 
+            this.tableLayoutPanel11.ColumnCount = 3;
+            this.tableLayoutPanel11.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 76F));
+            this.tableLayoutPanel11.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 413F));
+            this.tableLayoutPanel11.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel11.Controls.Add(this.label19, 0, 0);
+            this.tableLayoutPanel11.Controls.Add(this.boxMetadataTitle, 1, 0);
+            this.tableLayoutPanel11.Controls.Add(this.label20, 2, 0);
+            this.tableLayoutPanel11.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanel11.Location = new System.Drawing.Point(3, 16);
+            this.tableLayoutPanel11.Name = "tableLayoutPanel11";
+            this.tableLayoutPanel11.RowCount = 1;
+            this.tableLayoutPanel11.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel11.Size = new System.Drawing.Size(947, 27);
+            this.tableLayoutPanel11.TabIndex = 0;
+            // 
+            // label19
+            // 
+            this.label19.AutoSize = true;
+            this.label19.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.label19.Location = new System.Drawing.Point(3, 0);
+            this.label19.Name = "label19";
+            this.label19.Size = new System.Drawing.Size(70, 27);
+            this.label19.TabIndex = 0;
+            this.label19.Text = "Title:";
+            this.label19.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
+            // boxMetadataTitle
+            // 
+            this.boxMetadataTitle.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.boxMetadataTitle.Location = new System.Drawing.Point(79, 3);
+            this.boxMetadataTitle.Name = "boxMetadataTitle";
+            this.boxMetadataTitle.Size = new System.Drawing.Size(407, 20);
+            this.boxMetadataTitle.TabIndex = 1;
+            this.boxMetadataTitle.TextChanged += new System.EventHandler(this.UpdateArguments);
+            // 
+            // label20
+            // 
+            this.label20.AutoSize = true;
+            this.label20.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.label20.Location = new System.Drawing.Point(492, 0);
+            this.label20.Name = "label20";
+            this.label20.Size = new System.Drawing.Size(452, 27);
+            this.label20.TabIndex = 2;
+            this.label20.Text = "Adds a string of text to the metadata of the video, which can be used to indicate" +
+    " the source of a video, for example. Leave blank for no title.";
+            this.label20.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // groupBox4
+            // 
+            this.groupBox4.Controls.Add(this.tableLayoutPanel5);
+            this.groupBox4.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.groupBox4.Location = new System.Drawing.Point(3, 132);
+            this.groupBox4.Name = "groupBox4";
+            this.groupBox4.Size = new System.Drawing.Size(953, 137);
+            this.groupBox4.TabIndex = 4;
+            this.groupBox4.TabStop = false;
+            this.groupBox4.Text = "Video";
+            // 
+            // tableLayoutPanel5
+            // 
+            this.tableLayoutPanel5.ColumnCount = 3;
+            this.tableLayoutPanel5.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 76F));
+            this.tableLayoutPanel5.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 158F));
+            this.tableLayoutPanel5.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel5.Controls.Add(this.tableLayoutPanel9, 1, 1);
+            this.tableLayoutPanel5.Controls.Add(this.tableLayoutPanel7, 1, 3);
+            this.tableLayoutPanel5.Controls.Add(this.label15, 0, 3);
+            this.tableLayoutPanel5.Controls.Add(this.label6, 2, 3);
+            this.tableLayoutPanel5.Controls.Add(this.label14, 2, 2);
+            this.tableLayoutPanel5.Controls.Add(this.tableLayoutPanel8, 1, 2);
+            this.tableLayoutPanel5.Controls.Add(this.label12, 0, 2);
+            this.tableLayoutPanel5.Controls.Add(this.label11, 2, 1);
+            this.tableLayoutPanel5.Controls.Add(this.label10, 0, 1);
+            this.tableLayoutPanel5.Controls.Add(this.label5, 2, 0);
+            this.tableLayoutPanel5.Controls.Add(this.label2, 0, 0);
+            this.tableLayoutPanel5.Controls.Add(this.tableLayoutPanel6, 1, 0);
+            this.tableLayoutPanel5.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanel5.Location = new System.Drawing.Point(3, 16);
+            this.tableLayoutPanel5.Name = "tableLayoutPanel5";
+            this.tableLayoutPanel5.RowCount = 4;
+            this.tableLayoutPanel5.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 16.66667F));
+            this.tableLayoutPanel5.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 16.66667F));
+            this.tableLayoutPanel5.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 16.66667F));
+            this.tableLayoutPanel5.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 16.66667F));
+            this.tableLayoutPanel5.Size = new System.Drawing.Size(947, 118);
+            this.tableLayoutPanel5.TabIndex = 0;
+            // 
+            // tableLayoutPanel9
+            // 
+            this.tableLayoutPanel9.ColumnCount = 3;
+            this.tableLayoutPanel9.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.tableLayoutPanel9.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 16F));
+            this.tableLayoutPanel9.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.tableLayoutPanel9.Controls.Add(this.boxCropTo, 2, 0);
+            this.tableLayoutPanel9.Controls.Add(this.boxCropFrom, 0, 0);
+            this.tableLayoutPanel9.Controls.Add(this.label17, 1, 0);
+            this.tableLayoutPanel9.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanel9.Location = new System.Drawing.Point(76, 29);
+            this.tableLayoutPanel9.Margin = new System.Windows.Forms.Padding(0);
+            this.tableLayoutPanel9.Name = "tableLayoutPanel9";
+            this.tableLayoutPanel9.RowCount = 1;
+            this.tableLayoutPanel9.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel9.Size = new System.Drawing.Size(158, 29);
+            this.tableLayoutPanel9.TabIndex = 4;
+            // 
+            // boxCropTo
+            // 
+            this.boxCropTo.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.boxCropTo.Location = new System.Drawing.Point(90, 4);
+            this.boxCropTo.Name = "boxCropTo";
+            this.boxCropTo.Size = new System.Drawing.Size(65, 20);
+            this.boxCropTo.TabIndex = 2;
+            this.boxCropTo.TextChanged += new System.EventHandler(this.UpdateArguments);
+            // 
+            // boxCropFrom
+            // 
+            this.boxCropFrom.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.boxCropFrom.Location = new System.Drawing.Point(3, 4);
+            this.boxCropFrom.Name = "boxCropFrom";
+            this.boxCropFrom.Size = new System.Drawing.Size(65, 20);
+            this.boxCropFrom.TabIndex = 0;
+            this.boxCropFrom.TextChanged += new System.EventHandler(this.UpdateArguments);
+            // 
+            // label17
+            // 
+            this.label17.AutoSize = true;
+            this.label17.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.label17.Location = new System.Drawing.Point(71, 0);
+            this.label17.Margin = new System.Windows.Forms.Padding(0);
+            this.label17.Name = "label17";
+            this.label17.Size = new System.Drawing.Size(16, 29);
+            this.label17.TabIndex = 1;
+            this.label17.Text = "to";
+            this.label17.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // tableLayoutPanel7
+            // 
+            this.tableLayoutPanel7.ColumnCount = 2;
+            this.tableLayoutPanel7.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.tableLayoutPanel7.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 40F));
+            this.tableLayoutPanel7.Controls.Add(this.boxLimit, 0, 0);
+            this.tableLayoutPanel7.Controls.Add(this.label16, 1, 0);
+            this.tableLayoutPanel7.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanel7.Location = new System.Drawing.Point(76, 87);
+            this.tableLayoutPanel7.Margin = new System.Windows.Forms.Padding(0);
+            this.tableLayoutPanel7.Name = "tableLayoutPanel7";
+            this.tableLayoutPanel7.RowCount = 1;
+            this.tableLayoutPanel7.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel7.Size = new System.Drawing.Size(158, 31);
+            this.tableLayoutPanel7.TabIndex = 10;
+            // 
+            // boxLimit
+            // 
+            this.boxLimit.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.boxLimit.Location = new System.Drawing.Point(3, 5);
+            this.boxLimit.Name = "boxLimit";
+            this.boxLimit.Size = new System.Drawing.Size(112, 20);
+            this.boxLimit.TabIndex = 0;
+            this.boxLimit.TextChanged += new System.EventHandler(this.UpdateArguments);
+            // 
+            // label16
+            // 
+            this.label16.AutoSize = true;
+            this.label16.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.label16.Location = new System.Drawing.Point(121, 0);
+            this.label16.Name = "label16";
+            this.label16.Size = new System.Drawing.Size(34, 31);
+            this.label16.TabIndex = 1;
+            this.label16.Text = "MB";
+            this.label16.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // label15
+            // 
+            this.label15.AutoSize = true;
+            this.label15.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.label15.Location = new System.Drawing.Point(3, 87);
+            this.label15.Name = "label15";
+            this.label15.Size = new System.Drawing.Size(70, 31);
+            this.label15.TabIndex = 9;
+            this.label15.Text = "Size limit:";
+            this.label15.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
+            // label6
+            // 
+            this.label6.AutoSize = true;
+            this.label6.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.label6.Location = new System.Drawing.Point(237, 87);
+            this.label6.Name = "label6";
+            this.label6.Size = new System.Drawing.Size(707, 31);
+            this.label6.TabIndex = 11;
+            this.label6.Text = "Will adjust the quality to attempt to stay below this limit, and cut off the end " +
+    "of a video if needed. Leave blank for no limit. The limit on 4chan is 3 MB. If e" +
+    "ntering decimals use dots, not commas.";
+            this.label6.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // label14
+            // 
+            this.label14.AutoSize = true;
+            this.label14.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.label14.Location = new System.Drawing.Point(237, 58);
+            this.label14.Name = "label14";
+            this.label14.Size = new System.Drawing.Size(707, 29);
+            this.label14.TabIndex = 8;
+            this.label14.Text = "Advanced users only. Keep blank if you don\'t know what this means, it\'ll get calc" +
+    "ulated automatically based on size limit.";
+            this.label14.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // tableLayoutPanel8
+            // 
+            this.tableLayoutPanel8.ColumnCount = 2;
+            this.tableLayoutPanel8.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.tableLayoutPanel8.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 40F));
+            this.tableLayoutPanel8.Controls.Add(this.boxBitrate, 0, 0);
+            this.tableLayoutPanel8.Controls.Add(this.label13, 1, 0);
+            this.tableLayoutPanel8.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanel8.Location = new System.Drawing.Point(76, 58);
+            this.tableLayoutPanel8.Margin = new System.Windows.Forms.Padding(0);
+            this.tableLayoutPanel8.Name = "tableLayoutPanel8";
+            this.tableLayoutPanel8.RowCount = 1;
+            this.tableLayoutPanel8.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel8.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 26F));
+            this.tableLayoutPanel8.Size = new System.Drawing.Size(158, 29);
+            this.tableLayoutPanel8.TabIndex = 7;
+            // 
+            // boxBitrate
+            // 
+            this.boxBitrate.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.boxBitrate.Location = new System.Drawing.Point(3, 4);
+            this.boxBitrate.Name = "boxBitrate";
+            this.boxBitrate.Size = new System.Drawing.Size(112, 20);
+            this.boxBitrate.TabIndex = 0;
+            this.boxBitrate.TextChanged += new System.EventHandler(this.UpdateArguments);
+            // 
+            // label13
+            // 
+            this.label13.AutoSize = true;
+            this.label13.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.label13.Location = new System.Drawing.Point(121, 0);
+            this.label13.Name = "label13";
+            this.label13.Size = new System.Drawing.Size(34, 29);
+            this.label13.TabIndex = 1;
+            this.label13.Text = "Kb/s";
+            this.label13.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // label12
+            // 
+            this.label12.AutoSize = true;
+            this.label12.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.label12.Location = new System.Drawing.Point(3, 58);
+            this.label12.Name = "label12";
+            this.label12.Size = new System.Drawing.Size(70, 29);
+            this.label12.TabIndex = 6;
+            this.label12.Text = "Bitrate:";
+            this.label12.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
+            // label11
+            // 
+            this.label11.AutoSize = true;
+            this.label11.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.label11.Location = new System.Drawing.Point(237, 29);
+            this.label11.Name = "label11";
+            this.label11.Size = new System.Drawing.Size(707, 29);
+            this.label11.TabIndex = 5;
+            this.label11.Text = resources.GetString("label11.Text");
+            this.label11.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // label10
+            // 
+            this.label10.AutoSize = true;
+            this.label10.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.label10.Location = new System.Drawing.Point(3, 29);
+            this.label10.Name = "label10";
+            this.label10.Size = new System.Drawing.Size(70, 29);
+            this.label10.TabIndex = 3;
+            this.label10.Text = "Crop video:";
+            this.label10.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
+            // label5
+            // 
+            this.label5.AutoSize = true;
+            this.label5.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.label5.Location = new System.Drawing.Point(237, 0);
+            this.label5.Name = "label5";
+            this.label5.Size = new System.Drawing.Size(707, 29);
+            this.label5.TabIndex = 2;
+            this.label5.Text = "Enter nothing to keep resolution intact. Enter -1 in one of the fields to scale a" +
+    "ccording to aspect ratio.";
+            this.label5.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.label2.Location = new System.Drawing.Point(3, 0);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(70, 29);
+            this.label2.TabIndex = 0;
+            this.label2.Text = "Resolution:";
+            this.label2.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
+            // tableLayoutPanel6
+            // 
+            this.tableLayoutPanel6.ColumnCount = 3;
+            this.tableLayoutPanel6.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.tableLayoutPanel6.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 16F));
+            this.tableLayoutPanel6.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.tableLayoutPanel6.Controls.Add(this.boxResH, 2, 0);
+            this.tableLayoutPanel6.Controls.Add(this.boxResW, 0, 0);
+            this.tableLayoutPanel6.Controls.Add(this.label8, 1, 0);
+            this.tableLayoutPanel6.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanel6.Location = new System.Drawing.Point(76, 0);
+            this.tableLayoutPanel6.Margin = new System.Windows.Forms.Padding(0);
+            this.tableLayoutPanel6.Name = "tableLayoutPanel6";
+            this.tableLayoutPanel6.RowCount = 1;
+            this.tableLayoutPanel6.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel6.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 26F));
+            this.tableLayoutPanel6.Size = new System.Drawing.Size(158, 29);
+            this.tableLayoutPanel6.TabIndex = 1;
+            // 
+            // boxResH
+            // 
+            this.boxResH.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.boxResH.Location = new System.Drawing.Point(90, 4);
+            this.boxResH.Name = "boxResH";
+            this.boxResH.Size = new System.Drawing.Size(65, 20);
+            this.boxResH.TabIndex = 2;
+            this.boxResH.TextChanged += new System.EventHandler(this.UpdateArguments);
+            // 
+            // boxResW
+            // 
+            this.boxResW.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.boxResW.Location = new System.Drawing.Point(3, 4);
+            this.boxResW.Name = "boxResW";
+            this.boxResW.Size = new System.Drawing.Size(65, 20);
+            this.boxResW.TabIndex = 0;
+            this.boxResW.TextChanged += new System.EventHandler(this.UpdateArguments);
+            // 
+            // label8
+            // 
+            this.label8.AutoSize = true;
+            this.label8.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.label8.Location = new System.Drawing.Point(71, 0);
+            this.label8.Margin = new System.Windows.Forms.Padding(0);
+            this.label8.Name = "label8";
+            this.label8.Size = new System.Drawing.Size(16, 29);
+            this.label8.TabIndex = 1;
+            this.label8.Text = "x";
+            this.label8.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // groupBox1
             // 
@@ -121,7 +642,7 @@ namespace WebMConverter
             this.groupBox1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.groupBox1.Location = new System.Drawing.Point(3, 3);
             this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(947, 80);
+            this.groupBox1.Size = new System.Drawing.Size(953, 71);
             this.groupBox1.TabIndex = 0;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Main";
@@ -146,15 +667,15 @@ namespace WebMConverter
             this.tableLayoutPanel2.RowCount = 2;
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
-            this.tableLayoutPanel2.Size = new System.Drawing.Size(941, 61);
+            this.tableLayoutPanel2.Size = new System.Drawing.Size(947, 52);
             this.tableLayoutPanel2.TabIndex = 0;
             // 
             // buttonBrowseOut
             // 
             this.buttonBrowseOut.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.buttonBrowseOut.Location = new System.Drawing.Point(799, 33);
+            this.buttonBrowseOut.Location = new System.Drawing.Point(805, 29);
             this.buttonBrowseOut.Name = "buttonBrowseOut";
-            this.buttonBrowseOut.Size = new System.Drawing.Size(62, 25);
+            this.buttonBrowseOut.Size = new System.Drawing.Size(62, 20);
             this.buttonBrowseOut.TabIndex = 5;
             this.buttonBrowseOut.Text = "Browse";
             this.buttonBrowseOut.UseVisualStyleBackColor = true;
@@ -163,18 +684,18 @@ namespace WebMConverter
             // textBoxOut
             // 
             this.textBoxOut.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.textBoxOut.Location = new System.Drawing.Point(72, 35);
+            this.textBoxOut.Location = new System.Drawing.Point(72, 29);
             this.textBoxOut.Name = "textBoxOut";
-            this.textBoxOut.Size = new System.Drawing.Size(721, 20);
+            this.textBoxOut.Size = new System.Drawing.Size(727, 20);
             this.textBoxOut.TabIndex = 4;
             // 
             // label4
             // 
             this.label4.AutoSize = true;
             this.label4.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label4.Location = new System.Drawing.Point(3, 30);
+            this.label4.Location = new System.Drawing.Point(3, 26);
             this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(63, 31);
+            this.label4.Size = new System.Drawing.Size(63, 26);
             this.label4.TabIndex = 3;
             this.label4.Text = "Output file";
             this.label4.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
@@ -185,7 +706,7 @@ namespace WebMConverter
             this.label1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.label1.Location = new System.Drawing.Point(3, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(63, 30);
+            this.label1.Size = new System.Drawing.Size(63, 26);
             this.label1.TabIndex = 0;
             this.label1.Text = "Input file";
             this.label1.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
@@ -193,18 +714,18 @@ namespace WebMConverter
             // textBoxIn
             // 
             this.textBoxIn.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.textBoxIn.Location = new System.Drawing.Point(72, 5);
+            this.textBoxIn.Location = new System.Drawing.Point(72, 3);
             this.textBoxIn.Name = "textBoxIn";
-            this.textBoxIn.Size = new System.Drawing.Size(721, 20);
+            this.textBoxIn.Size = new System.Drawing.Size(727, 20);
             this.textBoxIn.TabIndex = 1;
             // 
             // buttonGo
             // 
             this.buttonGo.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.buttonGo.Location = new System.Drawing.Point(867, 3);
+            this.buttonGo.Location = new System.Drawing.Point(873, 3);
             this.buttonGo.Name = "buttonGo";
             this.tableLayoutPanel2.SetRowSpan(this.buttonGo, 2);
-            this.buttonGo.Size = new System.Drawing.Size(71, 55);
+            this.buttonGo.Size = new System.Drawing.Size(71, 46);
             this.buttonGo.TabIndex = 6;
             this.buttonGo.Text = "Convert";
             this.buttonGo.UseVisualStyleBackColor = true;
@@ -213,560 +734,39 @@ namespace WebMConverter
             // buttonBrowseIn
             // 
             this.buttonBrowseIn.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.buttonBrowseIn.Location = new System.Drawing.Point(799, 3);
+            this.buttonBrowseIn.Location = new System.Drawing.Point(805, 3);
             this.buttonBrowseIn.Name = "buttonBrowseIn";
-            this.buttonBrowseIn.Size = new System.Drawing.Size(62, 24);
+            this.buttonBrowseIn.Size = new System.Drawing.Size(62, 20);
             this.buttonBrowseIn.TabIndex = 2;
             this.buttonBrowseIn.Text = "Browse";
             this.buttonBrowseIn.UseVisualStyleBackColor = true;
             this.buttonBrowseIn.Click += new System.EventHandler(this.buttonBrowseIn_Click);
             // 
-            // groupBox2
-            // 
-            this.groupBox2.Controls.Add(this.tableLayoutPanel3);
-            this.groupBox2.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.groupBox2.Location = new System.Drawing.Point(3, 89);
-            this.groupBox2.Name = "groupBox2";
-            this.groupBox2.Size = new System.Drawing.Size(947, 346);
-            this.groupBox2.TabIndex = 1;
-            this.groupBox2.TabStop = false;
-            this.groupBox2.Text = "Configuration";
-            // 
-            // tableLayoutPanel3
-            // 
-            this.tableLayoutPanel3.ColumnCount = 1;
-            this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel3.Controls.Add(this.groupBox4, 0, 1);
-            this.tableLayoutPanel3.Controls.Add(this.groupBox3, 0, 0);
-            this.tableLayoutPanel3.Controls.Add(this.groupBox5, 0, 2);
-            this.tableLayoutPanel3.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel3.Location = new System.Drawing.Point(3, 16);
-            this.tableLayoutPanel3.Name = "tableLayoutPanel3";
-            this.tableLayoutPanel3.RowCount = 3;
-            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 47F));
-            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 57F));
-            this.tableLayoutPanel3.Size = new System.Drawing.Size(941, 327);
-            this.tableLayoutPanel3.TabIndex = 0;
-            // 
-            // groupBox4
-            // 
-            this.groupBox4.Controls.Add(this.tableLayoutPanel5);
-            this.groupBox4.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.groupBox4.Location = new System.Drawing.Point(3, 50);
-            this.groupBox4.Name = "groupBox4";
-            this.groupBox4.Size = new System.Drawing.Size(935, 217);
-            this.groupBox4.TabIndex = 1;
-            this.groupBox4.TabStop = false;
-            this.groupBox4.Text = "Video";
-            // 
-            // tableLayoutPanel5
-            // 
-            this.tableLayoutPanel5.ColumnCount = 3;
-            this.tableLayoutPanel5.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 76F));
-            this.tableLayoutPanel5.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 158F));
-            this.tableLayoutPanel5.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel5.Controls.Add(this.label18, 2, 5);
-            this.tableLayoutPanel5.Controls.Add(this.checkBox2Pass, 0, 5);
-            this.tableLayoutPanel5.Controls.Add(this.label9, 2, 4);
-            this.tableLayoutPanel5.Controls.Add(this.label7, 0, 4);
-            this.tableLayoutPanel5.Controls.Add(this.tableLayoutPanel9, 1, 1);
-            this.tableLayoutPanel5.Controls.Add(this.tableLayoutPanel7, 1, 3);
-            this.tableLayoutPanel5.Controls.Add(this.label15, 0, 3);
-            this.tableLayoutPanel5.Controls.Add(this.label6, 2, 3);
-            this.tableLayoutPanel5.Controls.Add(this.label14, 2, 2);
-            this.tableLayoutPanel5.Controls.Add(this.tableLayoutPanel8, 1, 2);
-            this.tableLayoutPanel5.Controls.Add(this.label12, 0, 2);
-            this.tableLayoutPanel5.Controls.Add(this.label11, 2, 1);
-            this.tableLayoutPanel5.Controls.Add(this.label10, 0, 1);
-            this.tableLayoutPanel5.Controls.Add(this.label5, 2, 0);
-            this.tableLayoutPanel5.Controls.Add(this.label2, 0, 0);
-            this.tableLayoutPanel5.Controls.Add(this.tableLayoutPanel6, 1, 0);
-            this.tableLayoutPanel5.Controls.Add(this.tableLayoutPanel10, 1, 4);
-            this.tableLayoutPanel5.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel5.Location = new System.Drawing.Point(3, 16);
-            this.tableLayoutPanel5.Name = "tableLayoutPanel5";
-            this.tableLayoutPanel5.RowCount = 6;
-            this.tableLayoutPanel5.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 16.66667F));
-            this.tableLayoutPanel5.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 16.66667F));
-            this.tableLayoutPanel5.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 16.66667F));
-            this.tableLayoutPanel5.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 16.66667F));
-            this.tableLayoutPanel5.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 16.66667F));
-            this.tableLayoutPanel5.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 16.66667F));
-            this.tableLayoutPanel5.Size = new System.Drawing.Size(929, 198);
-            this.tableLayoutPanel5.TabIndex = 0;
-            this.tableLayoutPanel5.Paint += new System.Windows.Forms.PaintEventHandler(this.tableLayoutPanel5_Paint);
-            // 
-            // label18
-            // 
-            this.label18.AutoSize = true;
-            this.label18.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label18.Location = new System.Drawing.Point(237, 165);
-            this.label18.Name = "label18";
-            this.label18.Size = new System.Drawing.Size(689, 33);
-            this.label18.TabIndex = 15;
-            this.label18.Text = resources.GetString("label18.Text");
-            this.label18.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            // 
-            // checkBox2Pass
-            // 
-            this.checkBox2Pass.CheckAlign = System.Drawing.ContentAlignment.MiddleRight;
-            this.tableLayoutPanel5.SetColumnSpan(this.checkBox2Pass, 2);
-            this.checkBox2Pass.Dock = System.Windows.Forms.DockStyle.Right;
-            this.checkBox2Pass.Location = new System.Drawing.Point(66, 168);
-            this.checkBox2Pass.Name = "checkBox2Pass";
-            this.checkBox2Pass.Size = new System.Drawing.Size(165, 27);
-            this.checkBox2Pass.TabIndex = 11;
-            this.checkBox2Pass.Text = "Enable 2-pass encoding:";
-            this.checkBox2Pass.UseVisualStyleBackColor = true;
-            // 
-            // label9
-            // 
-            this.label9.AutoSize = true;
-            this.label9.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label9.Location = new System.Drawing.Point(237, 132);
-            this.label9.Name = "label9";
-            this.label9.Size = new System.Drawing.Size(689, 33);
-            this.label9.TabIndex = 13;
-            this.label9.Text = "Advanced users only. Keep at default if you don\'t know what this means. Determine" +
-    "s amount of threads ffmpeg uses. Try setting this to 1 if ffmpeg.exe crashes as " +
-    "soon as you click Convert.";
-            this.label9.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            // 
-            // label7
-            // 
-            this.label7.AutoSize = true;
-            this.label7.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label7.Location = new System.Drawing.Point(3, 132);
-            this.label7.Name = "label7";
-            this.label7.Size = new System.Drawing.Size(70, 33);
-            this.label7.TabIndex = 12;
-            this.label7.Text = "Threads:";
-            this.label7.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-            // 
-            // tableLayoutPanel9
-            // 
-            this.tableLayoutPanel9.ColumnCount = 3;
-            this.tableLayoutPanel9.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
-            this.tableLayoutPanel9.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 16F));
-            this.tableLayoutPanel9.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
-            this.tableLayoutPanel9.Controls.Add(this.boxCropTo, 2, 0);
-            this.tableLayoutPanel9.Controls.Add(this.boxCropFrom, 0, 0);
-            this.tableLayoutPanel9.Controls.Add(this.label17, 1, 0);
-            this.tableLayoutPanel9.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel9.Location = new System.Drawing.Point(76, 33);
-            this.tableLayoutPanel9.Margin = new System.Windows.Forms.Padding(0);
-            this.tableLayoutPanel9.Name = "tableLayoutPanel9";
-            this.tableLayoutPanel9.RowCount = 1;
-            this.tableLayoutPanel9.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel9.Size = new System.Drawing.Size(158, 33);
-            this.tableLayoutPanel9.TabIndex = 4;
-            // 
-            // boxCropTo
-            // 
-            this.boxCropTo.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.boxCropTo.Location = new System.Drawing.Point(90, 6);
-            this.boxCropTo.Name = "boxCropTo";
-            this.boxCropTo.Size = new System.Drawing.Size(65, 20);
-            this.boxCropTo.TabIndex = 2;
-            // 
-            // boxCropFrom
-            // 
-            this.boxCropFrom.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.boxCropFrom.Location = new System.Drawing.Point(3, 6);
-            this.boxCropFrom.Name = "boxCropFrom";
-            this.boxCropFrom.Size = new System.Drawing.Size(65, 20);
-            this.boxCropFrom.TabIndex = 0;
-            // 
-            // label17
-            // 
-            this.label17.AutoSize = true;
-            this.label17.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label17.Location = new System.Drawing.Point(71, 0);
-            this.label17.Margin = new System.Windows.Forms.Padding(0);
-            this.label17.Name = "label17";
-            this.label17.Size = new System.Drawing.Size(16, 33);
-            this.label17.TabIndex = 1;
-            this.label17.Text = "to";
-            this.label17.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-            // 
-            // tableLayoutPanel7
-            // 
-            this.tableLayoutPanel7.ColumnCount = 2;
-            this.tableLayoutPanel7.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
-            this.tableLayoutPanel7.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 40F));
-            this.tableLayoutPanel7.Controls.Add(this.boxLimit, 0, 0);
-            this.tableLayoutPanel7.Controls.Add(this.label16, 1, 0);
-            this.tableLayoutPanel7.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel7.Location = new System.Drawing.Point(76, 99);
-            this.tableLayoutPanel7.Margin = new System.Windows.Forms.Padding(0);
-            this.tableLayoutPanel7.Name = "tableLayoutPanel7";
-            this.tableLayoutPanel7.RowCount = 1;
-            this.tableLayoutPanel7.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel7.Size = new System.Drawing.Size(158, 33);
-            this.tableLayoutPanel7.TabIndex = 10;
-            // 
-            // boxLimit
-            // 
-            this.boxLimit.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.boxLimit.Location = new System.Drawing.Point(3, 6);
-            this.boxLimit.Name = "boxLimit";
-            this.boxLimit.Size = new System.Drawing.Size(112, 20);
-            this.boxLimit.TabIndex = 0;
-            // 
-            // label16
-            // 
-            this.label16.AutoSize = true;
-            this.label16.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label16.Location = new System.Drawing.Point(121, 0);
-            this.label16.Name = "label16";
-            this.label16.Size = new System.Drawing.Size(34, 33);
-            this.label16.TabIndex = 1;
-            this.label16.Text = "MB";
-            this.label16.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            // 
-            // label15
-            // 
-            this.label15.AutoSize = true;
-            this.label15.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label15.Location = new System.Drawing.Point(3, 99);
-            this.label15.Name = "label15";
-            this.label15.Size = new System.Drawing.Size(70, 33);
-            this.label15.TabIndex = 9;
-            this.label15.Text = "Size limit:";
-            this.label15.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-            // 
-            // label6
-            // 
-            this.label6.AutoSize = true;
-            this.label6.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label6.Location = new System.Drawing.Point(237, 99);
-            this.label6.Name = "label6";
-            this.label6.Size = new System.Drawing.Size(689, 33);
-            this.label6.TabIndex = 11;
-            this.label6.Text = "Will adjust the quality to attempt to stay below this limit, and cut off the end " +
-    "of a video if needed. Leave blank for no limit. The limit on 4chan is 3 MB. If e" +
-    "ntering decimals use dots, not commas.";
-            this.label6.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            // 
-            // label14
-            // 
-            this.label14.AutoSize = true;
-            this.label14.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label14.Location = new System.Drawing.Point(237, 66);
-            this.label14.Name = "label14";
-            this.label14.Size = new System.Drawing.Size(689, 33);
-            this.label14.TabIndex = 8;
-            this.label14.Text = "Advanced users only. Keep blank if you don\'t know what this means, it\'ll get calc" +
-    "ulated automatically based on size limit.";
-            this.label14.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            // 
-            // tableLayoutPanel8
-            // 
-            this.tableLayoutPanel8.ColumnCount = 2;
-            this.tableLayoutPanel8.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
-            this.tableLayoutPanel8.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 40F));
-            this.tableLayoutPanel8.Controls.Add(this.boxBitrate, 0, 0);
-            this.tableLayoutPanel8.Controls.Add(this.label13, 1, 0);
-            this.tableLayoutPanel8.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel8.Location = new System.Drawing.Point(76, 66);
-            this.tableLayoutPanel8.Margin = new System.Windows.Forms.Padding(0);
-            this.tableLayoutPanel8.Name = "tableLayoutPanel8";
-            this.tableLayoutPanel8.RowCount = 1;
-            this.tableLayoutPanel8.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel8.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 32F));
-            this.tableLayoutPanel8.Size = new System.Drawing.Size(158, 33);
-            this.tableLayoutPanel8.TabIndex = 7;
-            // 
-            // boxBitrate
-            // 
-            this.boxBitrate.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.boxBitrate.Location = new System.Drawing.Point(3, 6);
-            this.boxBitrate.Name = "boxBitrate";
-            this.boxBitrate.Size = new System.Drawing.Size(112, 20);
-            this.boxBitrate.TabIndex = 0;
-            // 
-            // label13
-            // 
-            this.label13.AutoSize = true;
-            this.label13.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label13.Location = new System.Drawing.Point(121, 0);
-            this.label13.Name = "label13";
-            this.label13.Size = new System.Drawing.Size(34, 33);
-            this.label13.TabIndex = 1;
-            this.label13.Text = "Kb/s";
-            this.label13.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            // 
-            // label12
-            // 
-            this.label12.AutoSize = true;
-            this.label12.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label12.Location = new System.Drawing.Point(3, 66);
-            this.label12.Name = "label12";
-            this.label12.Size = new System.Drawing.Size(70, 33);
-            this.label12.TabIndex = 6;
-            this.label12.Text = "Bitrate:";
-            this.label12.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-            // 
-            // label11
-            // 
-            this.label11.AutoSize = true;
-            this.label11.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label11.Location = new System.Drawing.Point(237, 33);
-            this.label11.Name = "label11";
-            this.label11.Size = new System.Drawing.Size(689, 33);
-            this.label11.TabIndex = 5;
-            this.label11.Text = resources.GetString("label11.Text");
-            this.label11.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            // 
-            // label10
-            // 
-            this.label10.AutoSize = true;
-            this.label10.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label10.Location = new System.Drawing.Point(3, 33);
-            this.label10.Name = "label10";
-            this.label10.Size = new System.Drawing.Size(70, 33);
-            this.label10.TabIndex = 3;
-            this.label10.Text = "Crop video:";
-            this.label10.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-            // 
-            // label5
-            // 
-            this.label5.AutoSize = true;
-            this.label5.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label5.Location = new System.Drawing.Point(237, 0);
-            this.label5.Name = "label5";
-            this.label5.Size = new System.Drawing.Size(689, 33);
-            this.label5.TabIndex = 2;
-            this.label5.Text = "Enter nothing to keep resolution intact. Enter -1 in one of the fields to scale a" +
-    "ccording to aspect ratio.";
-            this.label5.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            // 
-            // label2
-            // 
-            this.label2.AutoSize = true;
-            this.label2.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label2.Location = new System.Drawing.Point(3, 0);
-            this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(70, 33);
-            this.label2.TabIndex = 0;
-            this.label2.Text = "Resolution:";
-            this.label2.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-            // 
-            // tableLayoutPanel6
-            // 
-            this.tableLayoutPanel6.ColumnCount = 3;
-            this.tableLayoutPanel6.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
-            this.tableLayoutPanel6.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 16F));
-            this.tableLayoutPanel6.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
-            this.tableLayoutPanel6.Controls.Add(this.boxResH, 2, 0);
-            this.tableLayoutPanel6.Controls.Add(this.boxResW, 0, 0);
-            this.tableLayoutPanel6.Controls.Add(this.label8, 1, 0);
-            this.tableLayoutPanel6.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel6.Location = new System.Drawing.Point(76, 0);
-            this.tableLayoutPanel6.Margin = new System.Windows.Forms.Padding(0);
-            this.tableLayoutPanel6.Name = "tableLayoutPanel6";
-            this.tableLayoutPanel6.RowCount = 1;
-            this.tableLayoutPanel6.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel6.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 32F));
-            this.tableLayoutPanel6.Size = new System.Drawing.Size(158, 33);
-            this.tableLayoutPanel6.TabIndex = 1;
-            // 
-            // boxResH
-            // 
-            this.boxResH.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.boxResH.Location = new System.Drawing.Point(90, 6);
-            this.boxResH.Name = "boxResH";
-            this.boxResH.Size = new System.Drawing.Size(65, 20);
-            this.boxResH.TabIndex = 2;
-            // 
-            // boxResW
-            // 
-            this.boxResW.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.boxResW.Location = new System.Drawing.Point(3, 6);
-            this.boxResW.Name = "boxResW";
-            this.boxResW.Size = new System.Drawing.Size(65, 20);
-            this.boxResW.TabIndex = 0;
-            // 
-            // label8
-            // 
-            this.label8.AutoSize = true;
-            this.label8.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label8.Location = new System.Drawing.Point(71, 0);
-            this.label8.Margin = new System.Windows.Forms.Padding(0);
-            this.label8.Name = "label8";
-            this.label8.Size = new System.Drawing.Size(16, 33);
-            this.label8.TabIndex = 1;
-            this.label8.Text = "x";
-            this.label8.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-            // 
-            // tableLayoutPanel10
-            // 
-            this.tableLayoutPanel10.ColumnCount = 2;
-            this.tableLayoutPanel10.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 86.18421F));
-            this.tableLayoutPanel10.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 13.81579F));
-            this.tableLayoutPanel10.Controls.Add(this.trackThreads, 0, 0);
-            this.tableLayoutPanel10.Controls.Add(this.labelThreads, 1, 0);
-            this.tableLayoutPanel10.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel10.Location = new System.Drawing.Point(79, 135);
-            this.tableLayoutPanel10.Name = "tableLayoutPanel10";
-            this.tableLayoutPanel10.RowCount = 1;
-            this.tableLayoutPanel10.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
-            this.tableLayoutPanel10.Size = new System.Drawing.Size(152, 27);
-            this.tableLayoutPanel10.TabIndex = 25;
-            // 
-            // trackThreads
-            // 
-            this.trackThreads.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.trackThreads.Location = new System.Drawing.Point(0, 0);
-            this.trackThreads.Margin = new System.Windows.Forms.Padding(0);
-            this.trackThreads.Maximum = 16;
-            this.trackThreads.Minimum = 1;
-            this.trackThreads.Name = "trackThreads";
-            this.trackThreads.Size = new System.Drawing.Size(131, 27);
-            this.trackThreads.TabIndex = 0;
-            this.trackThreads.Value = 1;
-            this.trackThreads.Scroll += new System.EventHandler(this.trackThreads_Scroll);
-            // 
-            // labelThreads
-            // 
-            this.labelThreads.AutoSize = true;
-            this.labelThreads.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.labelThreads.Location = new System.Drawing.Point(131, 0);
-            this.labelThreads.Margin = new System.Windows.Forms.Padding(0);
-            this.labelThreads.Name = "labelThreads";
-            this.labelThreads.Size = new System.Drawing.Size(21, 27);
-            this.labelThreads.TabIndex = 1;
-            this.labelThreads.Text = "1";
-            this.labelThreads.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            // 
-            // groupBox3
-            // 
-            this.groupBox3.Controls.Add(this.tableLayoutPanel4);
-            this.groupBox3.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.groupBox3.Location = new System.Drawing.Point(3, 3);
-            this.groupBox3.Name = "groupBox3";
-            this.groupBox3.Size = new System.Drawing.Size(935, 41);
-            this.groupBox3.TabIndex = 0;
-            this.groupBox3.TabStop = false;
-            this.groupBox3.Text = "Audio";
-            // 
-            // tableLayoutPanel4
-            // 
-            this.tableLayoutPanel4.ColumnCount = 2;
-            this.tableLayoutPanel4.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 233F));
-            this.tableLayoutPanel4.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel4.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-            this.tableLayoutPanel4.Controls.Add(this.label3, 1, 0);
-            this.tableLayoutPanel4.Controls.Add(this.checkBoxAudio, 0, 0);
-            this.tableLayoutPanel4.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel4.Location = new System.Drawing.Point(3, 16);
-            this.tableLayoutPanel4.Name = "tableLayoutPanel4";
-            this.tableLayoutPanel4.RowCount = 1;
-            this.tableLayoutPanel4.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel4.Size = new System.Drawing.Size(929, 22);
-            this.tableLayoutPanel4.TabIndex = 0;
-            // 
-            // label3
-            // 
-            this.label3.AutoSize = true;
-            this.label3.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label3.Location = new System.Drawing.Point(236, 0);
-            this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(690, 22);
-            this.label3.TabIndex = 1;
-            this.label3.Text = "Keep this unchecked until Moot allows WebM with audio.";
-            this.label3.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            // 
-            // checkBoxAudio
-            // 
-            this.checkBoxAudio.CheckAlign = System.Drawing.ContentAlignment.MiddleRight;
-            this.checkBoxAudio.Dock = System.Windows.Forms.DockStyle.Right;
-            this.checkBoxAudio.Location = new System.Drawing.Point(55, 3);
-            this.checkBoxAudio.Name = "checkBoxAudio";
-            this.checkBoxAudio.Size = new System.Drawing.Size(175, 16);
-            this.checkBoxAudio.TabIndex = 0;
-            this.checkBoxAudio.Text = "Enable audio:";
-            this.checkBoxAudio.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-            this.checkBoxAudio.UseVisualStyleBackColor = true;
-            // 
-            // groupBox5
-            // 
-            this.groupBox5.Controls.Add(this.tableLayoutPanel11);
-            this.groupBox5.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.groupBox5.Location = new System.Drawing.Point(3, 273);
-            this.groupBox5.Name = "groupBox5";
-            this.groupBox5.Size = new System.Drawing.Size(935, 51);
-            this.groupBox5.TabIndex = 2;
-            this.groupBox5.TabStop = false;
-            this.groupBox5.Text = "Metadata";
-            // 
-            // tableLayoutPanel11
-            // 
-            this.tableLayoutPanel11.ColumnCount = 3;
-            this.tableLayoutPanel11.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 76F));
-            this.tableLayoutPanel11.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 413F));
-            this.tableLayoutPanel11.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel11.Controls.Add(this.label19, 0, 0);
-            this.tableLayoutPanel11.Controls.Add(this.boxMetadataTitle, 1, 0);
-            this.tableLayoutPanel11.Controls.Add(this.label20, 2, 0);
-            this.tableLayoutPanel11.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel11.Location = new System.Drawing.Point(3, 16);
-            this.tableLayoutPanel11.Name = "tableLayoutPanel11";
-            this.tableLayoutPanel11.RowCount = 1;
-            this.tableLayoutPanel11.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel11.Size = new System.Drawing.Size(929, 32);
-            this.tableLayoutPanel11.TabIndex = 0;
-            // 
-            // label19
-            // 
-            this.label19.AutoSize = true;
-            this.label19.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label19.Location = new System.Drawing.Point(3, 0);
-            this.label19.Name = "label19";
-            this.label19.Size = new System.Drawing.Size(70, 32);
-            this.label19.TabIndex = 0;
-            this.label19.Text = "Title:";
-            this.label19.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-            // 
-            // boxMetadataTitle
-            // 
-            this.boxMetadataTitle.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.boxMetadataTitle.Location = new System.Drawing.Point(79, 6);
-            this.boxMetadataTitle.Name = "boxMetadataTitle";
-            this.boxMetadataTitle.Size = new System.Drawing.Size(407, 20);
-            this.boxMetadataTitle.TabIndex = 1;
-            // 
-            // label20
-            // 
-            this.label20.AutoSize = true;
-            this.label20.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label20.Location = new System.Drawing.Point(492, 0);
-            this.label20.Name = "label20";
-            this.label20.Size = new System.Drawing.Size(434, 32);
-            this.label20.TabIndex = 2;
-            this.label20.Text = "Adds a string of text to the metadata of the video, which can be used to indicate" +
-    " the source of a video, for example. Leave blank for no title.";
-            this.label20.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            // 
             // MainForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(959, 444);
+            this.ClientSize = new System.Drawing.Size(959, 432);
             this.Controls.Add(this.tableLayoutPanel1);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.Fixed3D;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-            this.MinimumSize = new System.Drawing.Size(975, 483);
+            this.MaximizeBox = false;
+            this.MinimumSize = new System.Drawing.Size(975, 470);
             this.Name = "MainForm";
             this.Padding = new System.Windows.Forms.Padding(3);
             this.Text = "WebM for Retards";
             this.Load += new System.EventHandler(this.MainForm_Load);
             this.tableLayoutPanel1.ResumeLayout(false);
-            this.groupBox1.ResumeLayout(false);
-            this.tableLayoutPanel2.ResumeLayout(false);
-            this.tableLayoutPanel2.PerformLayout();
-            this.groupBox2.ResumeLayout(false);
-            this.tableLayoutPanel3.ResumeLayout(false);
+            this.tableLayoutPanel1.PerformLayout();
+            this.groupBox3.ResumeLayout(false);
+            this.tableLayoutPanel4.ResumeLayout(false);
+            this.tableLayoutPanel4.PerformLayout();
+            this.tableLayoutPanel10.ResumeLayout(false);
+            this.tableLayoutPanel10.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.trackThreads)).EndInit();
+            this.groupBox5.ResumeLayout(false);
+            this.tableLayoutPanel11.ResumeLayout(false);
+            this.tableLayoutPanel11.PerformLayout();
             this.groupBox4.ResumeLayout(false);
             this.tableLayoutPanel5.ResumeLayout(false);
             this.tableLayoutPanel5.PerformLayout();
@@ -778,15 +778,9 @@ namespace WebMConverter
             this.tableLayoutPanel8.PerformLayout();
             this.tableLayoutPanel6.ResumeLayout(false);
             this.tableLayoutPanel6.PerformLayout();
-            this.tableLayoutPanel10.ResumeLayout(false);
-            this.tableLayoutPanel10.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.trackThreads)).EndInit();
-            this.groupBox3.ResumeLayout(false);
-            this.tableLayoutPanel4.ResumeLayout(false);
-            this.tableLayoutPanel4.PerformLayout();
-            this.groupBox5.ResumeLayout(false);
-            this.tableLayoutPanel11.ResumeLayout(false);
-            this.tableLayoutPanel11.PerformLayout();
+            this.groupBox1.ResumeLayout(false);
+            this.tableLayoutPanel2.ResumeLayout(false);
+            this.tableLayoutPanel2.PerformLayout();
             this.ResumeLayout(false);
 
         }
@@ -803,48 +797,47 @@ namespace WebMConverter
         private System.Windows.Forms.TextBox textBoxIn;
         private System.Windows.Forms.Button buttonGo;
         private System.Windows.Forms.Button buttonBrowseIn;
-        private System.Windows.Forms.GroupBox groupBox2;
-        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel3;
-        private System.Windows.Forms.GroupBox groupBox4;
         private System.Windows.Forms.GroupBox groupBox3;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel4;
-        private System.Windows.Forms.Label label3;
-        private System.Windows.Forms.CheckBox checkBoxAudio;
+        private System.Windows.Forms.Label label7;
+        private System.Windows.Forms.Label label9;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel10;
+        private System.Windows.Forms.TrackBar trackThreads;
+        private System.Windows.Forms.Label labelThreads;
+        private System.Windows.Forms.Label label18;
+        private System.Windows.Forms.CheckBox checkBox2Pass;
+        private System.Windows.Forms.GroupBox groupBox5;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel11;
+        private System.Windows.Forms.Label label19;
+        private System.Windows.Forms.TextBox boxMetadataTitle;
+        private System.Windows.Forms.Label label20;
+        private System.Windows.Forms.GroupBox groupBox4;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel5;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel9;
+        private System.Windows.Forms.TextBox boxCropTo;
+        private System.Windows.Forms.TextBox boxCropFrom;
+        private System.Windows.Forms.Label label17;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel7;
+        private System.Windows.Forms.TextBox boxLimit;
+        private System.Windows.Forms.Label label16;
+        private System.Windows.Forms.Label label15;
+        private System.Windows.Forms.Label label6;
+        private System.Windows.Forms.Label label14;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel8;
+        private System.Windows.Forms.TextBox boxBitrate;
+        private System.Windows.Forms.Label label13;
+        private System.Windows.Forms.Label label12;
+        private System.Windows.Forms.Label label11;
+        private System.Windows.Forms.Label label10;
         private System.Windows.Forms.Label label5;
         private System.Windows.Forms.Label label2;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel6;
         private System.Windows.Forms.TextBox boxResH;
         private System.Windows.Forms.TextBox boxResW;
         private System.Windows.Forms.Label label8;
-        private System.Windows.Forms.Label label11;
-        private System.Windows.Forms.Label label10;
-        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel8;
-        private System.Windows.Forms.TextBox boxBitrate;
-        private System.Windows.Forms.Label label13;
-        private System.Windows.Forms.Label label12;
-        private System.Windows.Forms.Label label14;
-        private System.Windows.Forms.Label label6;
-        private System.Windows.Forms.Label label15;
-        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel7;
-        private System.Windows.Forms.TextBox boxLimit;
-        private System.Windows.Forms.Label label16;
-        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel9;
-        private System.Windows.Forms.TextBox boxCropTo;
-        private System.Windows.Forms.TextBox boxCropFrom;
-        private System.Windows.Forms.Label label17;
-        private System.Windows.Forms.Label label7;
-        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel10;
-        private System.Windows.Forms.TrackBar trackThreads;
-        private System.Windows.Forms.Label labelThreads;
-        private System.Windows.Forms.Label label9;
-        private System.Windows.Forms.Label label18;
-        private System.Windows.Forms.GroupBox groupBox5;
-        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel11;
-        private System.Windows.Forms.Label label19;
-        private System.Windows.Forms.TextBox boxMetadataTitle;
-        private System.Windows.Forms.Label label20;
-        private System.Windows.Forms.CheckBox checkBox2Pass;
+        private System.Windows.Forms.Label label3;
+        private System.Windows.Forms.TextBox textBoxArguments;
+        private System.Windows.Forms.Label label21;
     }
 }
 

--- a/MainForm.resx
+++ b/MainForm.resx
@@ -117,9 +117,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="label18.Text" xml:space="preserve">
-    <value>Advanced users only. Keep unchecked if you don't know what this means. Will make ffmpeg use two passes, which can increase the quality/size ratio, but also increases the time it takes to encode. Disable if you run into any issues.</value>
-  </data>
   <data name="label11.Text" xml:space="preserve">
     <value>Crop off the start/end of the video. Leave both blank to use entire video. Leave start blank to start at the beginning, leave end blank to convert everything up to the end. Use notation HH:MM:SS, HH:MM:SS.MS or just the amount of seconds. If entering decimals use dots, not commas.</value>
   </data>


### PR DESCRIPTION
Separated argument generation and stuck the results in a control so advanced users can tweak things if necessary.

The behavior is that if you change a parameter that results in a new argument string, the argument textbox gets overwritten. When you hit "convert", it uses whatever's in the textbox.

![image](https://cloud.githubusercontent.com/assets/211868/2662740/8c00b31c-c044-11e3-8dda-22099df852d2.png)
